### PR TITLE
## [1.1.21] - 2023-06-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.21] - 2023-06-27
+- `ResponseNetworkDeviceGroupGetNetworkDeviceGroupByNameNetworkDeviceGroup`, `ResponseNetworkDeviceGroupGetNetworkDeviceGroupByIDNetworkDeviceGroup` and `RequestNetworkDeviceGroupUpdateNetworkDeviceGroupByIDNetworkDeviceGroup` change Ndgtype TO Othername on network_device_group.go.
+- Adding `ParentID` parameter on `ResponseEndpointIDentityGroupGetEndpointGroupByNameEndPointGroup` and `ResponseEndpointIDentityGroupGetEndpointGroupByIDEndPointGroup` structs on endpoint_identity_group.
+
 ## [1.1.20] - 2023-06-19
 - `RequestNetworkDeviceGroupCreateNetworkDeviceGroupNetworkDeviceGroup` change Ndgtype TO Othername on network_device_group.go.
 - Adding `ParentID` parameter on `RequestEndpointIDentityGroupCreateEndpointGroupEndPointGroup` struct on endpoint_identity_group.
@@ -206,4 +210,5 @@ Following parameters were added to `RequestNetworkAccessAuthenticationRulesCreat
 [1.1.18]: https://github.com/CiscoISE/ciscoise-go-sdk/compare/v1.1.17...v1.1.18
 [1.1.19]: https://github.com/CiscoISE/ciscoise-go-sdk/compare/v1.1.18...v1.1.19
 [1.1.20]: https://github.com/CiscoISE/ciscoise-go-sdk/compare/v1.1.19...v1.1.20
-[Unreleased]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v1.1.20...main
+[1.1.21]: https://github.com/CiscoISE/ciscoise-go-sdk/compare/v1.1.19...v1.1.20
+[Unreleased]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v1.1.21...main

--- a/sdk/endpoint_identity_group.go
+++ b/sdk/endpoint_identity_group.go
@@ -29,6 +29,7 @@ type ResponseEndpointIDentityGroupGetEndpointGroupByNameEndPointGroup struct {
 	Description   string                                                                `json:"description,omitempty"`   //
 	SystemDefined *bool                                                                 `json:"systemDefined,omitempty"` //
 	Link          *ResponseEndpointIDentityGroupGetEndpointGroupByNameEndPointGroupLink `json:"link,omitempty"`          //
+	ParentID      string                                                                `json:"parentId,omitempty"`      //
 }
 
 type ResponseEndpointIDentityGroupGetEndpointGroupByNameEndPointGroupLink struct {
@@ -47,6 +48,7 @@ type ResponseEndpointIDentityGroupGetEndpointGroupByIDEndPointGroup struct {
 	Description   string                                                              `json:"description,omitempty"`   //
 	SystemDefined *bool                                                               `json:"systemDefined,omitempty"` //
 	Link          *ResponseEndpointIDentityGroupGetEndpointGroupByIDEndPointGroupLink `json:"link,omitempty"`          //
+	ParentID      string                                                              `json:"parentId,omitempty"`      //
 }
 
 type ResponseEndpointIDentityGroupGetEndpointGroupByIDEndPointGroupLink struct {

--- a/sdk/network_device_group.go
+++ b/sdk/network_device_group.go
@@ -28,7 +28,7 @@ type ResponseNetworkDeviceGroupGetNetworkDeviceGroupByNameNetworkDeviceGroup str
 	Name        string                                                                       `json:"name,omitempty"`        //
 	Description string                                                                       `json:"description,omitempty"` //
 	Link        *ResponseNetworkDeviceGroupGetNetworkDeviceGroupByNameNetworkDeviceGroupLink `json:"link,omitempty"`        //
-	Ndgtype     string                                                                       `json:"ndgtype,omitempty"`     //
+	Othername   string                                                                       `json:"othername,omitempty"`   //
 }
 
 type ResponseNetworkDeviceGroupGetNetworkDeviceGroupByNameNetworkDeviceGroupLink struct {
@@ -46,7 +46,7 @@ type ResponseNetworkDeviceGroupGetNetworkDeviceGroupByIDNetworkDeviceGroup struc
 	Name        string                                                                     `json:"name,omitempty"`        //
 	Description string                                                                     `json:"description,omitempty"` //
 	Link        *ResponseNetworkDeviceGroupGetNetworkDeviceGroupByIDNetworkDeviceGroupLink `json:"link,omitempty"`        //
-	Ndgtype     string                                                                     `json:"ndgtype,omitempty"`     //
+	Othername   string                                                                     `json:"othername,omitempty"`   //
 }
 
 type ResponseNetworkDeviceGroupGetNetworkDeviceGroupByIDNetworkDeviceGroupLink struct {
@@ -132,7 +132,7 @@ type RequestNetworkDeviceGroupUpdateNetworkDeviceGroupByIDNetworkDeviceGroup str
 	ID          string `json:"id,omitempty"`          //
 	Name        string `json:"name,omitempty"`        //
 	Description string `json:"description,omitempty"` //
-	Ndgtype     string `json:"ndgtype,omitempty"`     //
+	Othername   string `json:"othername,omitempty"`   //
 }
 
 type RequestNetworkDeviceGroupCreateNetworkDeviceGroup struct {


### PR DESCRIPTION
- `ResponseNetworkDeviceGroupGetNetworkDeviceGroupByNameNetworkDeviceGroup`, `ResponseNetworkDeviceGroupGetNetworkDeviceGroupByIDNetworkDeviceGroup` and `RequestNetworkDeviceGroupUpdateNetworkDeviceGroupByIDNetworkDeviceGroup` change Ndgtype TO Othername on network_device_group.go.
- Adding `ParentID` parameter on `ResponseEndpointIDentityGroupGetEndpointGroupByNameEndPointGroup` and `ResponseEndpointIDentityGroupGetEndpointGroupByIDEndPointGroup` structs on endpoint_identity_group.