### PR TITLE
Added nested children support to fix issue #101  on terraform-provider-ciscoise repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.22] - 2023-08-08
+- Support for nested children conditions was added
+
 ## [1.1.21] - 2023-06-27
 - `ResponseNetworkDeviceGroupGetNetworkDeviceGroupByNameNetworkDeviceGroup`, `ResponseNetworkDeviceGroupGetNetworkDeviceGroupByIDNetworkDeviceGroup` and `RequestNetworkDeviceGroupUpdateNetworkDeviceGroupByIDNetworkDeviceGroup` change Ndgtype TO Othername on network_device_group.go.
 - Adding `ParentID` parameter on `ResponseEndpointIDentityGroupGetEndpointGroupByNameEndPointGroup` and `ResponseEndpointIDentityGroupGetEndpointGroupByIDEndPointGroup` structs on endpoint_identity_group.
@@ -210,5 +213,6 @@ Following parameters were added to `RequestNetworkAccessAuthenticationRulesCreat
 [1.1.18]: https://github.com/CiscoISE/ciscoise-go-sdk/compare/v1.1.17...v1.1.18
 [1.1.19]: https://github.com/CiscoISE/ciscoise-go-sdk/compare/v1.1.18...v1.1.19
 [1.1.20]: https://github.com/CiscoISE/ciscoise-go-sdk/compare/v1.1.19...v1.1.20
-[1.1.21]: https://github.com/CiscoISE/ciscoise-go-sdk/compare/v1.1.19...v1.1.20
-[Unreleased]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v1.1.21...main
+[1.1.21]: https://github.com/CiscoISE/ciscoise-go-sdk/compare/v1.1.20...v1.1.21
+[1.1.22]: https://github.com/CiscoISE/ciscoise-go-sdk/compare/v1.1.21...v1.1.22
+[Unreleased]: https://github.com/CiscoISE/ciscoise-go-sdk/compare/v1.1.22...main

--- a/examples/policy_sets/main.go
+++ b/examples/policy_sets/main.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	isegosdk "github.com/CiscoISE/ciscoise-go-sdk/sdk"
+)
+
+func main() {
+	Client, err := isegosdk.NewClientWithOptions("https://10.48.190.181",
+		"admin", "Cisco12345",
+		"false", "false",
+		"false", "false")
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// GET NETWORK ACCESS POLICY SETS
+	fmt.Println("executing GetNetworkAccessPolicySets...")
+	policy_sets, _, err := Client.NetworkAccessPolicySet.GetNetworkAccessPolicySets()
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	if policy_sets != nil && policy_sets.Response != nil {
+		for _, row := range *policy_sets.Response {
+			fmt.Println("-------------")
+			fmt.Println("ID: ", row.ID)
+			fmt.Println("Name: ", row.Name)
+			fmt.Println("Description: ", row.Description)
+			fmt.Println("Condition: ", row.Condition)
+			if row.Condition != nil {
+				fmt.Println("Children: ", row.Condition.Children)
+			}
+		}
+	}
+	fmt.Println("-------------")
+
+	// GET NETWORK ACCESS POLICY SETS BY ID
+	fmt.Println("executing GetNetworkAccessPolicySetsbyID...")
+	policy_set, _, err := Client.NetworkAccessPolicySet.GetNetworkAccessPolicySetByID("13727e31-93d1-4fc6-9a7e-80f6998b1916")
+
+	if err != nil {
+		fmt.Println(err)
+	}
+	if policy_set != nil && policy_set.Response != nil {
+
+		fmt.Println("-------------")
+		fmt.Println("ID: ", policy_set.Response.ID)
+		fmt.Println("Name: ", policy_set.Response.Name)
+		fmt.Println("Description: ", policy_set.Response.Description)
+		fmt.Println("Condition: ", policy_set.Response.Condition)
+		if policy_set.Response.Condition != nil {
+			fmt.Println("Children: ", policy_set.Response.Condition.Children)
+		}
+	}
+	fmt.Println("-------------")
+
+	falseVal := false
+
+	policy_set1 := &isegosdk.RequestNetworkAccessPolicySetCreateNetworkAccessPolicySet{
+		Name:        "Test_9983",
+		Description: "Sample policy_set using ciscoise-go-sdk",
+		ServiceName: "Default Network Access",
+		State:       "enabled",
+		IsProxy:     &falseVal,
+		Condition: &isegosdk.RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetCondition{
+			ConditionType: "ConditionAndBlock",
+			IsNegate:      &falseVal,
+			Children: &[]isegosdk.RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetCondition{
+				{
+					ConditionType: "ConditionReference",
+					ID:            "49ec9c17-6987-43ef-9478-a42111c59b81",
+				},
+				{
+					ConditionType: "ConditionReference",
+					ID:            "1e9f02d0-13e7-4a3b-8fbc-fb38330d74b5",
+				},
+				{
+					ConditionType: "ConditionAndBlock",
+					IsNegate:      &falseVal,
+					Children: &[]isegosdk.RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetCondition{
+						{
+							ConditionType: "ConditionReference",
+							ID:            "49ec9c17-6987-43ef-9478-a42111c59b81",
+						},
+						{
+							ConditionType: "ConditionReference",
+							ID:            "1e9f02d0-13e7-4a3b-8fbc-fb38330d74b5",
+						},
+						{
+							ConditionType: "ConditionAndBlock",
+							IsNegate:      &falseVal,
+							Children: &[]isegosdk.RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetCondition{
+								{
+									ConditionType: "ConditionReference",
+									ID:            "49ec9c17-6987-43ef-9478-a42111c59b81",
+								},
+								{
+									ConditionType: "ConditionReference",
+									ID:            "1e9f02d0-13e7-4a3b-8fbc-fb38330d74b5",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	policy_set2 := &isegosdk.RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByID{
+		Name:        "Test_02",
+		Description: "Sample policy_set using ciscoise-go-sdk",
+		ServiceName: "Default Network Access",
+		State:       "enabled",
+		IsProxy:     &falseVal,
+		Condition: &isegosdk.RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDCondition{
+			ConditionType: "ConditionAndBlock",
+			IsNegate:      &falseVal,
+			Children: &[]isegosdk.RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDCondition{
+				{
+					ConditionType: "ConditionReference",
+					ID:            "49ec9c17-6987-43ef-9478-a42111c59b81",
+				},
+				{
+					ConditionType: "ConditionReference",
+					ID:            "1e9f02d0-13e7-4a3b-8fbc-fb38330d74b5",
+				},
+				{
+					ConditionType: "ConditionAndBlock",
+					IsNegate:      &falseVal,
+					Children: &[]isegosdk.RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDCondition{
+						{
+							ConditionType: "ConditionReference",
+							ID:            "49ec9c17-6987-43ef-9478-a42111c59b81",
+						},
+						{
+							ConditionType: "ConditionReference",
+							ID:            "1e9f02d0-13e7-4a3b-8fbc-fb38330d74b5",
+						},
+						{
+							ConditionType: "ConditionAndBlock",
+							IsNegate:      &falseVal,
+							Children: &[]isegosdk.RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDCondition{
+								{
+									ConditionType: "ConditionReference",
+									ID:            "49ec9c17-6987-43ef-9478-a42111c59b81",
+								},
+								{
+									ConditionType: "ConditionReference",
+									ID:            "1e9f02d0-13e7-4a3b-8fbc-fb38330d74b5",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	//CREATE NETWORK ACCESS POLICY SET
+	fmt.Println("executing CreatePolicySet...")
+	policy_set_create, _, err := Client.NetworkAccessPolicySet.CreateNetworkAccessPolicySet(policy_set1)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	if policy_set_create != nil {
+		fmt.Println(policy_set_create.Response)
+	}
+
+	//UPDATE NEWORK ACCESS POLICY SET BY ID
+	fmt.Println("executing UpdateNetworkAccessPolicySetByID...")
+	policy_setByID, _, err := Client.NetworkAccessPolicySet.UpdateNetworkAccessPolicySetByID("575b7017-e53d-4c66-a20c-d6794822321e", policy_set2)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	if policy_setByID != nil {
+		fmt.Println(policy_setByID.Response)
+	}
+}

--- a/examples/repository/main.go
+++ b/examples/repository/main.go
@@ -9,8 +9,8 @@ import (
 
 func main() {
 	// New client definition
-	Client, err := isegosdk.NewClientWithOptions("https://198.18.133.27",
-		"admin", "C1sco12345",
+	Client, err := isegosdk.NewClientWithOptions("https://10.48.35.230",
+		"admin", "Devnet.12345",
 		"false", "false",
 		"false", "false")
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kuba-mazurkiewicz/ciscoise-go-sdk
+module github.com/CiscoISE/ciscoise-go-sdk
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/CiscoISE/ciscoise-go-sdk
+module github.com/kuba-mazurkiewicz/ciscoise-go-sdk
 
 go 1.15
 

--- a/sdk/network_access_policy_set.go
+++ b/sdk/network_access_policy_set.go
@@ -40,7 +40,7 @@ type ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetsResponseCondition s
 	ID                  string                                                                                        `json:"id,omitempty"`                  //
 	Name                string                                                                                        `json:"name,omitempty"`                // Condition name
 	DictionaryValue     string                                                                                        `json:"dictionaryValue,omitempty"`     // Dictionary value
-	Children            *[]ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetsResponseConditionChildren          `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
+	Children            *[]ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetsResponseCondition                  `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
 	DatesRange          *ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetsResponseConditionDatesRange          `json:"datesRange,omitempty"`          // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	DatesRangeException *ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetsResponseConditionDatesRangeException `json:"datesRangeException,omitempty"` // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	HoursRange          *ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetsResponseConditionHoursRange          `json:"hoursRange,omitempty"`          // <p>Defines for which hours a TimeAndDate condition will be matched<br> Time format - hh:mm  ( h = hour , mm = minutes ) <br> Default - All Day </p>
@@ -50,26 +50,6 @@ type ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetsResponseCondition s
 }
 
 type ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetsResponseConditionLink struct {
-	Href string `json:"href,omitempty"` //
-	Rel  string `json:"rel,omitempty"`  //
-	Type string `json:"type,omitempty"` //
-}
-
-type ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetsResponseConditionChildren struct {
-	ConditionType   string                                                                                 `json:"conditionType,omitempty"`   // <ul><li>Inidicates whether the record is the condition itself(data) or a logical(or,and) aggregation</li> <li>Data type enum(reference,single) indicates than "conditonId" OR "ConditionAttrs" fields should contain condition data but not both</li> <li>Logical aggreation(and,or) enum indicates that additional conditions are present under the children field</li></ul>
-	IsNegate        *bool                                                                                  `json:"isNegate,omitempty"`        // Indicates whereas this condition is in negate mode
-	Link            *ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetsResponseConditionChildrenLink `json:"link,omitempty"`            //
-	DictionaryName  string                                                                                 `json:"dictionaryName,omitempty"`  // Dictionary Name
-	AttributeName   string                                                                                 `json:"attributeName,omitempty"`   // Atribute Name
-	Operator        string                                                                                 `json:"operator,omitempty"`        // Operator
-	AttributeValue  string                                                                                 `json:"attributeValue,omitempty"`  // Attibute Name
-	Description     string                                                                                 `json:"description,omitempty"`     // Condition description
-	ID              string                                                                                 `json:"id,omitempty"`              //
-	Name            string                                                                                 `json:"name,omitempty"`            // Condition name
-	DictionaryValue string                                                                                 `json:"dictionaryValue,omitempty"` // Dictionary value
-}
-
-type ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetsResponseConditionChildrenLink struct {
 	Href string `json:"href,omitempty"` //
 	Rel  string `json:"rel,omitempty"`  //
 	Type string `json:"type,omitempty"` //
@@ -132,7 +112,7 @@ type ResponseNetworkAccessPolicySetCreateNetworkAccessPolicySetResponseCondition
 	ID                  string                                                                                          `json:"id,omitempty"`                  //
 	Name                string                                                                                          `json:"name,omitempty"`                // Condition name
 	DictionaryValue     string                                                                                          `json:"dictionaryValue,omitempty"`     // Dictionary value
-	Children            *[]ResponseNetworkAccessPolicySetCreateNetworkAccessPolicySetResponseConditionChildren          `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
+	Children            *[]ResponseNetworkAccessPolicySetCreateNetworkAccessPolicySetResponseCondition                  `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
 	DatesRange          *ResponseNetworkAccessPolicySetCreateNetworkAccessPolicySetResponseConditionDatesRange          `json:"datesRange,omitempty"`          // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	DatesRangeException *ResponseNetworkAccessPolicySetCreateNetworkAccessPolicySetResponseConditionDatesRangeException `json:"datesRangeException,omitempty"` // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	HoursRange          *ResponseNetworkAccessPolicySetCreateNetworkAccessPolicySetResponseConditionHoursRange          `json:"hoursRange,omitempty"`          // <p>Defines for which hours a TimeAndDate condition will be matched<br> Time format - hh:mm  ( h = hour , mm = minutes ) <br> Default - All Day </p>
@@ -142,26 +122,6 @@ type ResponseNetworkAccessPolicySetCreateNetworkAccessPolicySetResponseCondition
 }
 
 type ResponseNetworkAccessPolicySetCreateNetworkAccessPolicySetResponseConditionLink struct {
-	Href string `json:"href,omitempty"` //
-	Rel  string `json:"rel,omitempty"`  //
-	Type string `json:"type,omitempty"` //
-}
-
-type ResponseNetworkAccessPolicySetCreateNetworkAccessPolicySetResponseConditionChildren struct {
-	ConditionType   string                                                                                   `json:"conditionType,omitempty"`   // <ul><li>Inidicates whether the record is the condition itself(data) or a logical(or,and) aggregation</li> <li>Data type enum(reference,single) indicates than "conditonId" OR "ConditionAttrs" fields should contain condition data but not both</li> <li>Logical aggreation(and,or) enum indicates that additional conditions are present under the children field</li></ul>
-	IsNegate        *bool                                                                                    `json:"isNegate,omitempty"`        // Indicates whereas this condition is in negate mode
-	Link            *ResponseNetworkAccessPolicySetCreateNetworkAccessPolicySetResponseConditionChildrenLink `json:"link,omitempty"`            //
-	DictionaryName  string                                                                                   `json:"dictionaryName,omitempty"`  // Dictionary Name
-	AttributeName   string                                                                                   `json:"attributeName,omitempty"`   // Atribute Name
-	Operator        string                                                                                   `json:"operator,omitempty"`        // Operator
-	AttributeValue  string                                                                                   `json:"attributeValue,omitempty"`  // Attibute Name
-	Description     string                                                                                   `json:"description,omitempty"`     // Condition description
-	ID              string                                                                                   `json:"id,omitempty"`              //
-	Name            string                                                                                   `json:"name,omitempty"`            // Condition name
-	DictionaryValue string                                                                                   `json:"dictionaryValue,omitempty"` // Dictionary value
-}
-
-type ResponseNetworkAccessPolicySetCreateNetworkAccessPolicySetResponseConditionChildrenLink struct {
 	Href string `json:"href,omitempty"` //
 	Rel  string `json:"rel,omitempty"`  //
 	Type string `json:"type,omitempty"` //
@@ -228,7 +188,7 @@ type ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetByIDResponseConditio
 	ID                  string                                                                                           `json:"id,omitempty"`                  //
 	Name                string                                                                                           `json:"name,omitempty"`                // Condition name
 	DictionaryValue     string                                                                                           `json:"dictionaryValue,omitempty"`     // Dictionary value
-	Children            *[]ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetByIDResponseConditionChildren          `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
+	Children            *[]ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetByIDResponseCondition                  `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
 	DatesRange          *ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetByIDResponseConditionDatesRange          `json:"datesRange,omitempty"`          // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	DatesRangeException *ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetByIDResponseConditionDatesRangeException `json:"datesRangeException,omitempty"` // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	HoursRange          *ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetByIDResponseConditionHoursRange          `json:"hoursRange,omitempty"`          // <p>Defines for which hours a TimeAndDate condition will be matched<br> Time format - hh:mm  ( h = hour , mm = minutes ) <br> Default - All Day </p>
@@ -238,26 +198,6 @@ type ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetByIDResponseConditio
 }
 
 type ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetByIDResponseConditionLink struct {
-	Href string `json:"href,omitempty"` //
-	Rel  string `json:"rel,omitempty"`  //
-	Type string `json:"type,omitempty"` //
-}
-
-type ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetByIDResponseConditionChildren struct {
-	ConditionType   string                                                                                    `json:"conditionType,omitempty"`   // <ul><li>Inidicates whether the record is the condition itself(data) or a logical(or,and) aggregation</li> <li>Data type enum(reference,single) indicates than "conditonId" OR "ConditionAttrs" fields should contain condition data but not both</li> <li>Logical aggreation(and,or) enum indicates that additional conditions are present under the children field</li></ul>
-	IsNegate        *bool                                                                                     `json:"isNegate,omitempty"`        // Indicates whereas this condition is in negate mode
-	Link            *ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetByIDResponseConditionChildrenLink `json:"link,omitempty"`            //
-	DictionaryName  string                                                                                    `json:"dictionaryName,omitempty"`  // Dictionary Name
-	AttributeName   string                                                                                    `json:"attributeName,omitempty"`   // Atribute Name
-	Operator        string                                                                                    `json:"operator,omitempty"`        // Operator
-	AttributeValue  string                                                                                    `json:"attributeValue,omitempty"`  // Attibute Name
-	Description     string                                                                                    `json:"description,omitempty"`     // Condition description
-	ID              string                                                                                    `json:"id,omitempty"`              //
-	Name            string                                                                                    `json:"name,omitempty"`            // Condition name
-	DictionaryValue string                                                                                    `json:"dictionaryValue,omitempty"` // Dictionary value
-}
-
-type ResponseNetworkAccessPolicySetGetNetworkAccessPolicySetByIDResponseConditionChildrenLink struct {
 	Href string `json:"href,omitempty"` //
 	Rel  string `json:"rel,omitempty"`  //
 	Type string `json:"type,omitempty"` //
@@ -320,7 +260,7 @@ type ResponseNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDResponseCondi
 	ID                  string                                                                                              `json:"id,omitempty"`                  //
 	Name                string                                                                                              `json:"name,omitempty"`                // Condition name
 	DictionaryValue     string                                                                                              `json:"dictionaryValue,omitempty"`     // Dictionary value
-	Children            *[]ResponseNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDResponseConditionChildren          `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
+	Children            *[]ResponseNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDResponseCondition                  `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
 	DatesRange          *ResponseNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDResponseConditionDatesRange          `json:"datesRange,omitempty"`          // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	DatesRangeException *ResponseNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDResponseConditionDatesRangeException `json:"datesRangeException,omitempty"` // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	HoursRange          *ResponseNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDResponseConditionHoursRange          `json:"hoursRange,omitempty"`          // <p>Defines for which hours a TimeAndDate condition will be matched<br> Time format - hh:mm  ( h = hour , mm = minutes ) <br> Default - All Day </p>
@@ -330,26 +270,6 @@ type ResponseNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDResponseCondi
 }
 
 type ResponseNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDResponseConditionLink struct {
-	Href string `json:"href,omitempty"` //
-	Rel  string `json:"rel,omitempty"`  //
-	Type string `json:"type,omitempty"` //
-}
-
-type ResponseNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDResponseConditionChildren struct {
-	ConditionType   string                                                                                       `json:"conditionType,omitempty"`   // <ul><li>Inidicates whether the record is the condition itself(data) or a logical(or,and) aggregation</li> <li>Data type enum(reference,single) indicates than "conditonId" OR "ConditionAttrs" fields should contain condition data but not both</li> <li>Logical aggreation(and,or) enum indicates that additional conditions are present under the children field</li></ul>
-	IsNegate        *bool                                                                                        `json:"isNegate,omitempty"`        // Indicates whereas this condition is in negate mode
-	Link            *ResponseNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDResponseConditionChildrenLink `json:"link,omitempty"`            //
-	DictionaryName  string                                                                                       `json:"dictionaryName,omitempty"`  // Dictionary Name
-	AttributeName   string                                                                                       `json:"attributeName,omitempty"`   // Atribute Name
-	Operator        string                                                                                       `json:"operator,omitempty"`        // Operator
-	AttributeValue  string                                                                                       `json:"attributeValue,omitempty"`  // Attibute Name
-	Description     string                                                                                       `json:"description,omitempty"`     // Condition description
-	ID              string                                                                                       `json:"id,omitempty"`              //
-	Name            string                                                                                       `json:"name,omitempty"`            // Condition name
-	DictionaryValue string                                                                                       `json:"dictionaryValue,omitempty"` // Dictionary value
-}
-
-type ResponseNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDResponseConditionChildrenLink struct {
 	Href string `json:"href,omitempty"` //
 	Rel  string `json:"rel,omitempty"`  //
 	Type string `json:"type,omitempty"` //
@@ -411,7 +331,7 @@ type RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetCondition struct {
 	ID                  string                                                                                 `json:"id,omitempty"`                  //
 	Name                string                                                                                 `json:"name,omitempty"`                // Condition name
 	DictionaryValue     string                                                                                 `json:"dictionaryValue,omitempty"`     // Dictionary value
-	Children            *[]RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetConditionChildren          `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
+	Children            *[]RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetCondition                  `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
 	DatesRange          *RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetConditionDatesRange          `json:"datesRange,omitempty"`          // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	DatesRangeException *RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetConditionDatesRangeException `json:"datesRangeException,omitempty"` // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	HoursRange          *RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetConditionHoursRange          `json:"hoursRange,omitempty"`          // <p>Defines for which hours a TimeAndDate condition will be matched<br> Time format - hh:mm  ( h = hour , mm = minutes ) <br> Default - All Day </p>
@@ -421,26 +341,6 @@ type RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetCondition struct {
 }
 
 type RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetConditionLink struct {
-	Href string `json:"href,omitempty"` //
-	Rel  string `json:"rel,omitempty"`  //
-	Type string `json:"type,omitempty"` //
-}
-
-type RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetConditionChildren struct {
-	ConditionType   string                                                                          `json:"conditionType,omitempty"`   // <ul><li>Inidicates whether the record is the condition itself(data) or a logical(or,and) aggregation</li> <li>Data type enum(reference,single) indicates than "conditonId" OR "ConditionAttrs" fields should contain condition data but not both</li> <li>Logical aggreation(and,or) enum indicates that additional conditions are present under the children field</li></ul>
-	IsNegate        *bool                                                                           `json:"isNegate,omitempty"`        // Indicates whereas this condition is in negate mode
-	Link            *RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetConditionChildrenLink `json:"link,omitempty"`            //
-	DictionaryName  string                                                                          `json:"dictionaryName,omitempty"`  // Dictionary Name
-	AttributeName   string                                                                          `json:"attributeName,omitempty"`   // Atribute Name
-	Operator        string                                                                          `json:"operator,omitempty"`        // Operator
-	AttributeValue  string                                                                          `json:"attributeValue,omitempty"`  // Attibute Name
-	Description     string                                                                          `json:"description,omitempty"`     // Condition description
-	ID              string                                                                          `json:"id,omitempty"`              //
-	Name            string                                                                          `json:"name,omitempty"`            // Condition name
-	DictionaryValue string                                                                          `json:"dictionaryValue,omitempty"` // Dictionary value
-}
-
-type RequestNetworkAccessPolicySetCreateNetworkAccessPolicySetConditionChildrenLink struct {
 	Href string `json:"href,omitempty"` //
 	Rel  string `json:"rel,omitempty"`  //
 	Type string `json:"type,omitempty"` //
@@ -498,7 +398,7 @@ type RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDCondition stru
 	ID                  string                                                                                     `json:"id,omitempty"`                  //
 	Name                string                                                                                     `json:"name,omitempty"`                // Condition name
 	DictionaryValue     string                                                                                     `json:"dictionaryValue,omitempty"`     // Dictionary value
-	Children            *[]RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDConditionChildren          `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
+	Children            *[]RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDCondition                  `json:"children,omitempty"`            // In case type is andBlock or orBlock addtional conditions will be aggregated under this logical (OR/AND) condition
 	DatesRange          *RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDConditionDatesRange          `json:"datesRange,omitempty"`          // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	DatesRangeException *RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDConditionDatesRangeException `json:"datesRangeException,omitempty"` // <p>Defines for which date/s TimeAndDate condition will be matched<br> Options are - Date range, for specific date, the same date should be used for start/end date <br> Default - no specific dates<br> In order to reset the dates to have no specific dates Date format - yyyy-mm-dd (MM = month, dd = day, yyyy = year)</p>
 	HoursRange          *RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDConditionHoursRange          `json:"hoursRange,omitempty"`          // <p>Defines for which hours a TimeAndDate condition will be matched<br> Time format - hh:mm  ( h = hour , mm = minutes ) <br> Default - All Day </p>
@@ -508,26 +408,6 @@ type RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDCondition stru
 }
 
 type RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDConditionLink struct {
-	Href string `json:"href,omitempty"` //
-	Rel  string `json:"rel,omitempty"`  //
-	Type string `json:"type,omitempty"` //
-}
-
-type RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDConditionChildren struct {
-	ConditionType   string                                                                              `json:"conditionType,omitempty"`   // <ul><li>Inidicates whether the record is the condition itself(data) or a logical(or,and) aggregation</li> <li>Data type enum(reference,single) indicates than "conditonId" OR "ConditionAttrs" fields should contain condition data but not both</li> <li>Logical aggreation(and,or) enum indicates that additional conditions are present under the children field</li></ul>
-	IsNegate        *bool                                                                               `json:"isNegate,omitempty"`        // Indicates whereas this condition is in negate mode
-	Link            *RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDConditionChildrenLink `json:"link,omitempty"`            //
-	DictionaryName  string                                                                              `json:"dictionaryName,omitempty"`  // Dictionary Name
-	AttributeName   string                                                                              `json:"attributeName,omitempty"`   // Atribute Name
-	Operator        string                                                                              `json:"operator,omitempty"`        // Operator
-	AttributeValue  string                                                                              `json:"attributeValue,omitempty"`  // Attibute Name
-	Description     string                                                                              `json:"description,omitempty"`     // Condition description
-	ID              string                                                                              `json:"id,omitempty"`              //
-	Name            string                                                                              `json:"name,omitempty"`            // Condition name
-	DictionaryValue string                                                                              `json:"dictionaryValue,omitempty"` // Dictionary value
-}
-
-type RequestNetworkAccessPolicySetUpdateNetworkAccessPolicySetByIDConditionChildrenLink struct {
 	Href string `json:"href,omitempty"` //
 	Rel  string `json:"rel,omitempty"`  //
 	Type string `json:"type,omitempty"` //


### PR DESCRIPTION
Modified network_access_policy_set.go to suport nested childrens, remove unecessary duplicated type to follow DRY principle.  Tested with examples/policy_sets/main.go on multiple children levels.